### PR TITLE
wire up root node checks

### DIFF
--- a/dt-validate.py
+++ b/dt-validate.py
@@ -28,9 +28,11 @@ class schema_group():
 
         # Check that the selection schema is valid. The selection
         # schema determines when a binding should get applied
+        resolver = jsonschema.RefResolver.from_schema(schema)
+        validator = jsonschema.Draft4Validator(schema, resolver=resolver)
         if "select" in schema.keys():
             try:
-                jsonschema.Draft4Validator.check_schema(schema)
+                validator.check_schema(schema)
             except jsonschema.SchemaError as exc:
                 print("Error(s) validating schema", filename, exc)
                 return
@@ -43,10 +45,11 @@ class schema_group():
         #print("checking node", path, "against a schemas")
         for schema in self.schemas:
             if "select" in schema.keys():
-                v = jsonschema.Draft4Validator(schema["select"])
+                resolver = jsonschema.RefResolver.from_schema(schema)
+                v = jsonschema.Draft4Validator(schema["select"], resolver=resolver)
                 if v.is_valid(node):
                     print("node", path, "matches", schema["filename"])
-                    v2 = jsonschema.Draft4Validator(schema)
+                    v2 = jsonschema.Draft4Validator(schema, resolver=resolver)
                     errors = sorted(v2.iter_errors(node), key=lambda e: e.path)
                     if (errors):
                         for error in errors:

--- a/schemas/root-node.yaml
+++ b/schemas/root-node.yaml
@@ -14,10 +14,23 @@ maintainer:
 # this binding is selected when the compatible property constraint matches
 #  selected: "compatible"
 
+select:
+  required: ["$path"]
+  properties:
+    $path: { enum: ["/"] }
+
 properties:
+  compatible:
+    type: array
+    items:
+      - type: string
   model:
     type: string
     description: models that this board family supports
+  "#address-cells":
+    type: number
+  "#size-cells":
+    type: number
 
 required:
   - compatible

--- a/schemas/soc/arm/juno.yaml
+++ b/schemas/soc/arm/juno.yaml
@@ -10,7 +10,7 @@ title: ARM Juno boards
 select:
   required: ["compatible", "$path"]
   properties:
-    $path: { const: "/" }
+    $path: { enum: ["/"] }
     compatible:
       contains:
         enum: [ "arm,juno", "arm,juno-r1", "arm,juno-r2" ]


### PR DESCRIPTION
Took me some time to figure out why root-node.yaml matched on everything. "const" was silently ignored since it is draft 6. That also means the use of "contains" is not working.